### PR TITLE
Fix Empty RaidStatus value on iDRAC causes modeling failure

### DIFF
--- a/txwsman/enumerate.py
+++ b/txwsman/enumerate.py
@@ -626,7 +626,7 @@ class Item(object):
 
     def __getitem__(self, x):
 
-        return getattr(self, str(x))
+        return getattr(self, str(x), None)
 
 
 class ItemsAccumulator(object):


### PR DESCRIPTION
Fixes ZPS-6522.

related: https://github.com/zenoss/ZenPacks.zenoss.Dell.PowerEdge/pull/188